### PR TITLE
Add support for fastparse-byte

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,3 +152,23 @@ lazy val core = crossProject
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val byte = crossProject
+  .crossType(CrossType.Pure)
+  .in(file("byte"))
+  .settings(name := "fastparse-cats-byte")
+  .settings(moduleName := "fastparse-cats-byte")
+  .settings(fastparseCatsSettings: _*)
+  .settings(libraryDependencies ++= Seq(
+      "com.lihaoyi" %%% "fastparse-byte" % fastparseVersion))
+  //.settings(mimaPreviousArtifacts := Set(previousArtifact("core")))
+  .disablePlugins(JmhPlugin)
+  .jsSettings(commonJsSettings: _*)
+  .jsSettings(coverageEnabled := false)
+  .jvmSettings(commonJvmSettings: _*)
+  .dependsOn(core)
+
+
+lazy val byteJVM = byte.jvm
+lazy val byteJS = byte.js
+

--- a/byte/src/main/scala/org/bykn/fastparse_cats/ByteInstances.scala
+++ b/byte/src/main/scala/org/bykn/fastparse_cats/ByteInstances.scala
@@ -1,0 +1,7 @@
+package org.bykn.fastparse_cats
+
+import scodec.bits.ByteVector
+
+object ByteInstances extends FastParseCatsGeneric[Byte, ByteVector] {
+  val api = fastparse.byte.all
+}

--- a/core/src/main/scala/org/bykn/fastparse_cats/FastParseCatsGeneric.scala
+++ b/core/src/main/scala/org/bykn/fastparse_cats/FastParseCatsGeneric.scala
@@ -1,10 +1,13 @@
 package org.bykn.fastparse_cats
 
-import cats.{Alternative, Eval, Functor, Monad}
+import cats.{Alternative, Eval, Now, Monad}
 import fastparse.Api
 import fastparse.core
 import fastparse.core.{ParserApi, ParserApiImpl}
 
+/**
+ * This is a module that gives the instances for any Elem or Repr
+ */
 abstract class FastParseCatsGeneric[Elem, Repr] {
 
   val api: Api[Elem, Repr]
@@ -16,62 +19,68 @@ abstract class FastParseCatsGeneric[Elem, Repr] {
     new ParserApiImpl[V, Elem, Repr](p)
 
   /**
-   * From an Eval, wait to build the Parser until we run
+   * This creates a namespace so we don't pollute
+   * when users do import StringInstances._
    */
-  def fromEval[A](e: Eval[Parser[A]]): Parser[A] =
-    new Parser[A] {
-      private[this] lazy val parser = e.value
+  object buildParser {
+    def pure[A](a: A): Parser[A] =
+      PassWith(a)
 
-      def parseRec(cfg: ParseCtx[Elem, Repr], index: Int): Mutable[A, Elem, Repr] =
-        parser.parseRec(cfg, index)
-    }
+    def fromEval[A](e: Eval[A]): Parser[A] =
+      e match {
+        case Now(a) => pure(a)
+        case notNow => delay(notNow.value)
+      }
+    /**
+     * From an Eval, wait to build the Parser until we actually need to parse
+     * if it is not already constructed.
+     *
+     * Note, we always store the value and only call .value on time since parsers
+     * are often applied at many locations.
+     */
+    def fromEvalParser[A](e: Eval[Parser[A]]): Parser[A] =
+      e match {
+        case Now(p) => p
+        case notNow => suspend(notNow.value)
+      }
 
-  // Mutable is of course, mutable, so this is not super safe
-  private implicit val mutableFunctor: Functor[Mutable[?, Elem, Repr]] = new Functor[Mutable[?, Elem, Repr]] {
-    def map[A, B](fa: Mutable[A, Elem, Repr])(fn: A => B): Mutable[B, Elem, Repr] =
-      fa match {
-        case Mutable.Success(a, i, t, c) =>
-          Mutable.Success(fn(a), i, t, c)
-        case f: Mutable.Failure[_, _] => f
-        case subclass =>
-          subclass.toResult match {
-            case Parsed.Success(a, i) =>
-              Mutable.Success(fn(a), i, subclass.traceParsers, subclass.cut)
-            case Parsed.Failure(_, _, _) =>
-              // this cast is safe because Failure has type Nothing
-              subclass.asInstanceOf[Mutable[B, Elem, Repr]]
-          }
+    /**
+     * Create a lazy value that is only evaluate when we parse
+     */
+    def delay[A](a: => A): Parser[A] =
+      suspend(PassWith(a))
+
+    /**
+     * wait to build the Parser until we actually need to parse.
+     *
+     * Note, we always store the value and only call the thunk once
+     * since Parsers are often applied at many locations.
+     */
+    def suspend[A](thunk: => Parser[A]): Parser[A] =
+      new Parser[A] {
+        private[this] lazy val parser = thunk
+
+        def parseRec(cfg: ParseCtx[Elem, Repr], index: Int): Mutable[A, Elem, Repr] =
+          parser.parseRec(cfg, index)
       }
   }
 
+  /**
+   * This gives you a lawful Monad and Alternative, which allows you to write
+   * many parser combinators purely on Monad or Alternative.
+   */
   implicit val monadParser: Monad[Parser] with Alternative[Parser] = new Monad[Parser] with Alternative[Parser] {
     def empty[A]: Parser[A] = Fail
     def combineK[A](left: Parser[A], right: Parser[A]): Parser[A] = left | right
 
-    def pure[A](a: A): Parser[A] = Pass.map(_ => a)
+    def pure[A](a: A): Parser[A] = PassWith(a)
+    override def unit = Pass
 
     override def map[A, B](fa: Parser[A])(fn: A => B): Parser[B] =
       fa.map(fn)
 
     override def map2Eval[A, B, C](fa: Parser[A], fb: Eval[Parser[B]])(fn: (A, B) => C): Eval[Parser[C]] =
-      Eval.now(new Parser[C] {
-        lazy val parserB = fb.value
-
-        def parseRec(cfg: ParseCtx[Elem, Repr], index: Int): Mutable[C, Elem, Repr] =
-          fa.parseRec(cfg, index) match {
-            case Mutable.Success(a, nextIdx, _, _) =>
-              mutableFunctor.map(parserB.parseRec(cfg, nextIdx))(fn(a, _))
-            case f: Mutable.Failure[_, _] => f
-            case subclass =>
-              subclass.toResult match {
-                case Parsed.Success(a, i) =>
-                  mutableFunctor.map(parserB.parseRec(cfg, i))(fn(a, _))
-                case Parsed.Failure(_, _, _) =>
-                  // this cast is safe because Failure has type Nothing
-                  subclass.asInstanceOf[Mutable[C, Elem, Repr]]
-              }
-          }
-      })
+      Eval.now(fa.flatMap { a => buildParser.fromEvalParser(fb).map { b => fn(a, b) } })
 
     override def replicateA[A](cnt: Int, fa: Parser[A]): Parser[List[A]] =
       fa.rep(cnt).map(_.toList)
@@ -109,8 +118,4 @@ abstract class FastParseCatsGeneric[Elem, Repr] {
         }
       }
   }
-}
-
-object FastParseCats extends FastParseCatsGeneric[Char, String] {
-  val api = fastparse.all
 }

--- a/core/src/main/scala/org/bykn/fastparse_cats/StringInstances.scala
+++ b/core/src/main/scala/org/bykn/fastparse_cats/StringInstances.scala
@@ -1,0 +1,5 @@
+package org.bykn.fastparse_cats
+
+object StringInstances extends FastParseCatsGeneric[Char, String] {
+  val api = fastparse.all
+}

--- a/core/src/test/scala/org/bykn/fastparse_cats/FastParseCatsLaws.scala
+++ b/core/src/test/scala/org/bykn/fastparse_cats/FastParseCatsLaws.scala
@@ -1,0 +1,66 @@
+package org.bykn.fastparse_cats
+
+import fastparse.all._
+import cats._
+import cats.tests.CatsSuite
+import cats.laws.discipline.{AlternativeTests, MonadTests, SemigroupalTests}
+
+import org.scalacheck.{Arbitrary, Gen}
+
+import StringInstances._
+import buildParser._
+
+class FastParseCatsLaws extends CatsSuite {
+
+  val genIntParse: Gen[Parser[Int]] =
+    Arbitrary.arbitrary[Int].map { i =>
+      val stri = i.toString
+      P(stri).map(_ => i)
+    }
+
+  implicit lazy val arbParse: Arbitrary[Parser[Int]] =
+    Arbitrary(Gen.oneOf(genIntParse,
+      Gen.const(Fail),
+      Arbitrary.arbitrary[Int].map(delay(_))))
+
+  implicit val genFn: Gen[Parser[Int => Int]] =
+    Arbitrary.arbitrary[Int].map { i =>
+      val stri = i.toString
+      P(stri).map { _ => { j => j * i } }
+    }
+
+  implicit val arbParseFn: Arbitrary[Parser[Int => Int]] =
+    Arbitrary(Gen.oneOf(genFn,
+      Gen.const(Fail),
+      Arbitrary.arbitrary[Int => Int].map(delay(_))))
+
+  implicit def eqP[A: Eq](implicit arbStr: Arbitrary[String]): Eq[Parser[A]] =
+    new Eq[Parser[A]] {
+      def eqv(left: P[A], right: P[A]) = {
+        (0 to 1000).forall { _ =>
+          arbStr.arbitrary.sample.forall { str =>
+            (left.parse(str), right.parse(str)) match {
+              case (Parsed.Success(pa, a), Parsed.Success(pb, b)) =>
+                pa == pb && a == b
+              case (Parsed.Failure(_, _, _), Parsed.Failure(_, _, _)) =>
+                //idxA == idxB
+                // TODO, this may be too weak, but Alternative right distributivity fails without
+                true
+              case _ => false
+            }
+          }
+        }
+      }
+    }
+
+  implicit val iso: SemigroupalTests.Isomorphisms[Parser] = SemigroupalTests.Isomorphisms.invariant[Parser]
+
+  checkAll("Parser[Int]", SemigroupalTests[Parser].semigroupal[Int, Int, Int])
+  checkAll("Parser[Int]", MonadTests[Parser].monad[Int, Int, Int])
+  checkAll("Parser[Int]", AlternativeTests[Parser].alternative[Int, Int, Int])
+
+  test("parser equality works") {
+    assert(eqP[Unit].eqv(Pass, Pass))
+    assert(eqP[Unit].eqv(AnyChar, AnyChar))
+  }
+}


### PR DESCRIPTION
* improved the factoring of the code
* used PassWith for pure
* added some useful methods to suspend parsers
* removed the need to special case map2Eval
* removed the private functor on Mutable.

